### PR TITLE
Allowing UseAsyncSuffixAnalyzer to ignore property getter and setters

### DIFF
--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Naming/UseAsyncSuffixUnitTests.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Naming/UseAsyncSuffixUnitTests.cs
@@ -143,6 +143,19 @@ class ClassName
             await VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        public async Task TestPropertyGetterAndSetterTaskAsync()
+        {
+            string testCode = @"
+using System.Threading.Tasks;
+class ClassName
+{
+    public Task<string> TaskString { get; set; }
+}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new UseAsyncSuffixAnalyzer();

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Naming/UseAsyncSuffixAnalyzer.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Naming/UseAsyncSuffixAnalyzer.cs
@@ -58,6 +58,9 @@
             if (!string.Equals(typeof(Task).Namespace, symbol.ReturnType?.ContainingNamespace?.ToString(), StringComparison.Ordinal))
                 return;
 
+            if (symbol.MethodKind == MethodKind.PropertyGet || symbol.MethodKind == MethodKind.PropertySet)
+                return;
+
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, symbol.Locations[0], symbol.Name));
         }
     }


### PR DESCRIPTION
[#21] Allowing UseAsyncSuffixAnalyzer to ignore property getter and setters;

I've never contributed via github before, so please let me know if this is the incorrect process to follow.

Fixes #21