### PR TITLE
Include AsyncUsageAnalyzers.CodeFixes in Visual Studio extension.

### DIFF
--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Vsix/source.extension.vsixmanifest
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Vsix/source.extension.vsixmanifest
@@ -17,5 +17,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="AsyncUsageAnalyzers" Path="|AsyncUsageAnalyzers|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="AsyncUsageAnalyzers" Path="|AsyncUsageAnalyzers|"/>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="AsyncUsageAnalyzers.CodeFixes" Path="|AsyncUsageAnalyzers.CodeFixes|" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="AsyncUsageAnalyzers.CodeFixes" Path="|AsyncUsageAnalyzers.CodeFixes|" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
Code fixes from AsyncUsageAnalyzers.CodeFixes don't work in Visual Studio because AsyncUsageAnalyzers.CodeFixes is not listed in vsixmanifest file.

This pull request contains a simple update which fixes the issue.