### PR TITLE
Don't use Thread.Sleep() analyzers - initial implementation

### DIFF
--- a/AsyncUsageAnalyzers.sln
+++ b/AsyncUsageAnalyzers.sln
@@ -32,6 +32,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 	ProjectSection(SolutionItems) = preProject
 		documentation\AvoidAsyncSuffix.md = documentation\AvoidAsyncSuffix.md
 		documentation\AvoidAsyncVoid.md = documentation\AvoidAsyncVoid.md
+		DontUseThreadSleep.md = DontUseThreadSleep.md
+		DontUseThreadSleepInAsyncCode.md = DontUseThreadSleepInAsyncCode.md
 		documentation\UseAsyncSuffix.md = documentation\UseAsyncSuffix.md
 		documentation\UseConfigureAwait.md = documentation\UseConfigureAwait.md
 	EndProjectSection

--- a/AsyncUsageAnalyzers.sln
+++ b/AsyncUsageAnalyzers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AsyncUsageAnalyzers", "AsyncUsageAnalyzers\AsyncUsageAnalyzers\AsyncUsageAnalyzers.csproj", "{4E32037D-3EE0-419A-BC68-7D28FCD453A0}"
 EndProject

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/AsyncUsageAnalyzers.CodeFixes.csproj
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/AsyncUsageAnalyzers.CodeFixes.csproj
@@ -80,24 +80,24 @@
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -120,15 +120,15 @@
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha003\analyzers\dotnet\AsyncUsageAnalyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/AsyncUsageAnalyzers.CodeFixes.csproj
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/AsyncUsageAnalyzers.CodeFixes.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Naming\AvoidAsyncSuffixCodeFixProvider.cs" />
     <Compile Include="Naming\UseAsyncSuffixCodeFixProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Usage\DontUseThreadSleepCodeUniversalCodeFixProvider.cs" />
     <Compile Include="Usage\UseConfigureAwaitCodeFixProvider.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/Usage/DontUseThreadSleepCodeUniversalCodeFixProvider.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/Usage/DontUseThreadSleepCodeUniversalCodeFixProvider.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Usage
+{
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Text;
+
+    [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = nameof(DontUseThreadSleepCodeUniversalCodeFixProvider))]
+    [Shared]
+    internal class DontUseThreadSleepCodeUniversalCodeFixProvider : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> FixableDiagnostics =
+                ImmutableArray.Create(DontUseThreadSleepAnalyzer.DiagnosticId, DontUseThreadSleepInAsyncCodeAnalyzer.DiagnosticId);
+
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return CustomFixAllProviders.BatchFixer;
+        }
+
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                if (diagnostic.Id == DontUseThreadSleepInAsyncCodeAnalyzer.DiagnosticId)
+                {
+                    RegisterCodeFixForDiagnosic(context, diagnostic);
+                }
+                else if (diagnostic.Id == DontUseThreadSleepAnalyzer.DiagnosticId)
+                {
+                    var document = context.Document;
+
+                    var root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+                    var invocationExpression = root.FindNode(TextSpan.FromBounds(diagnostic.Location.SourceSpan.Start, diagnostic.Location.SourceSpan.End), getInnermostNodeForTie: true) as InvocationExpressionSyntax;
+
+                    if (invocationExpression == null)
+                    {
+                        return;
+                    }
+
+                    if (invocationExpression.IsInsideAsyncCode())
+                    {
+                        RegisterCodeFixForDiagnosic(context, diagnostic);
+                    }
+                }
+            }
+        }
+
+        private static void RegisterCodeFixForDiagnosic(CodeFixContext context, Diagnostic diagnostic)
+        {
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    "Use await System.Threading.Tasks.Task.Delay(...)",
+                    cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)),
+                diagnostic);
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var firstNodeWithCorrectSpan = root
+                .FindNode(diagnostic.Location.SourceSpan);
+            InvocationExpressionSyntax expression = firstNodeWithCorrectSpan
+                .DescendantNodesAndSelf()
+                .OfType<InvocationExpressionSyntax>()
+                .First();
+
+            var arguments = expression.ArgumentList;
+
+            var newExpression = GenerateTaskDelayExpression(arguments);
+
+            SyntaxNode newRoot = root.ReplaceNode(expression, newExpression.WithTriviaFrom(expression));
+            var newDocument = document.WithSyntaxRoot(newRoot);
+            return newDocument;
+        }
+
+        private static AwaitExpressionSyntax GenerateTaskDelayExpression(ArgumentListSyntax methodArgumentList) =>
+            SyntaxFactory.AwaitExpression(
+                SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                SyntaxFactory.MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    SyntaxFactory.IdentifierName("System"),
+                                    SyntaxFactory.IdentifierName("Threading")),
+                                SyntaxFactory.IdentifierName("Tasks")),
+                            SyntaxFactory.IdentifierName("Task")),
+                        SyntaxFactory.IdentifierName("Delay")))
+                    .WithArgumentList(methodArgumentList));
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/packages.config
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.CodeFixes/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="portable45-net45+win8" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="portable45-net45+win8" />
   <package id="StyleCop.Analyzers" version="1.0.0-rc3" targetFramework="portable45-net45+win8" developmentDependency="true" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="portable45-net45+win8" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="portable45-net45+win8" />
   <package id="Tvl.NuGet.BuildTasks" version="1.0.0-alpha002" targetFramework="portable45-net45+win8" />
 </packages>

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/AsyncUsageAnalyzers.Test.csproj
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/AsyncUsageAnalyzers.Test.csproj
@@ -126,6 +126,9 @@
     <Compile Include="Naming\AvoidAsyncSuffixUnitTests.cs" />
     <Compile Include="Naming\UseAsyncSuffixUnitTests.cs" />
     <Compile Include="Reliability\AvoidAsyncVoidUnitTests.cs" />
+    <Compile Include="Usage\DontUseThreadSleepTestsBase.cs" />
+    <Compile Include="Usage\DontUseThreadSleepInAsyncCodeTests.cs" />
+    <Compile Include="Usage\DontUseThreadSleepTests.cs" />
     <Compile Include="Usage\IncludeCancellationParameterUnitTests.cs" />
     <Compile Include="Usage\UseConfigureAwaitUnitTests.cs" />
     <Compile Include="Verifiers\CodeFixVerifier.cs" />

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/AsyncUsageAnalyzers.Test.csproj
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/AsyncUsageAnalyzers.Test.csproj
@@ -44,29 +44,29 @@
     <AssemblyOriginatorKeyFile>..\..\build\keys\TestingKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -90,8 +90,8 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
@@ -155,8 +155,8 @@
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha003\analyzers\dotnet\AsyncUsageAnalyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Usage/DontUseThreadSleepInAsyncCodeTests.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Usage/DontUseThreadSleepInAsyncCodeTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Test.Usage
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AsyncUsageAnalyzers.Usage;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using TestHelper;
+    using Xunit;
+
+    public class DontUseThreadSleepInAsyncCodeTests : DontUseThreadSleepTestsBase
+    {
+        protected override DiagnosticResult OptionallyAddArgumentsToDiagnostic(DiagnosticResult diagnostic, params object[] arguments) =>
+            diagnostic.WithArguments(arguments);
+
+        [Fact]
+        public async Task TestThreadSleepInNonAsyncCodeAsync()
+        {
+            string testCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ClassA
+{
+    public delegate void SampleDelegate();
+    SampleDelegate AnonymousMethod = delegate ()
+    {
+        Thread.Sleep(0);
+    };
+
+    Func<int,int> testFunc = (x) =>
+    {
+        Thread.Sleep(0);
+        return x;
+    };
+
+    public void NonAsyncMethod()
+    {
+        Thread.Sleep(1000);
+        System.Threading.Thread.Sleep(1000);
+        global::System.Threading.Thread.Sleep(1000);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new DontUseThreadSleepInAsyncCodeAnalyzer();
+        }
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Usage/DontUseThreadSleepTests.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Usage/DontUseThreadSleepTests.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Test.Usage
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AsyncUsageAnalyzers.Usage;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using TestHelper;
+    using Xunit;
+
+    public class DontUseThreadSleepTests : DontUseThreadSleepTestsBase
+    {
+        protected override DiagnosticResult OptionallyAddArgumentsToDiagnostic(DiagnosticResult diagnostic, params object[] arguments) =>
+            diagnostic;
+
+        [Fact]
+        public async Task TestThreadSleepInMethodAsync()
+        {
+            var testCode = @"
+using System.Threading.Tasks;
+using System.Threading;
+
+class ClassA
+{
+    public void NonAsyncMethod()
+    {
+        Thread.Sleep(1000);
+        System.Threading.Thread.Sleep(1000);
+        global::System.Threading.Thread.Sleep(1000);
+    }
+}";
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(9, 9),
+                this.CSharpDiagnostic().WithLocation(10, 9),
+                this.CSharpDiagnostic().WithLocation(11, 9)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(
+                    testCode,
+                    testCode /* source code should not be changed as there's no automatic code fix */,
+                    cancellationToken: CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreadSleepInAnonymousFunctionAsync()
+        {
+            var testCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ClassA
+{
+    Func<int,int> testFunc = (x) =>
+    {
+        Thread.Sleep(0);
+        return x;
+    };
+}";
+            var expected = this.CSharpDiagnostic().WithLocation(10, 9);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(
+                    testCode,
+                    testCode /* source code should not be changed as there's no automatic code fix */,
+                    cancellationToken: CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreadSleepInAnonymousMethodAsync()
+        {
+            var testCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ClassA
+{
+    public delegate void SampleDelegate();
+    SampleDelegate AnonymousMethod = delegate ()
+    {
+        Thread.Sleep(0);
+    };
+}";
+            var expected = this.CSharpDiagnostic().WithLocation(11, 9);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(
+                    testCode,
+                    testCode /* source code should not be changed as there's no automatic code fix */,
+                    cancellationToken: CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new DontUseThreadSleepAnalyzer();
+        }
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Usage/DontUseThreadSleepTestsBase.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/Usage/DontUseThreadSleepTestsBase.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Test.Usage
+{
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AsyncUsageAnalyzers.Usage;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using TestHelper;
+    using Xunit;
+
+    public abstract class DontUseThreadSleepTestsBase : CodeFixVerifier
+    {
+        /// <summary>
+        /// Returns a new diagnostic with updated arguments or leaves a diagnostic intact.
+        /// </summary>
+        /// <param name="diagnostic">a diagnostic to be modified</param>
+        /// <param name="arguments">arguments which can be used to update diagnostic</param>
+        /// <returns>An appropriately modified diagnostic or unchanged diagnostic</returns>
+        protected abstract DiagnosticResult OptionallyAddArgumentsToDiagnostic(DiagnosticResult diagnostic, params object[] arguments);
+
+        [Fact]
+        public async Task TestThreadSleepInAsyncMethodAsync()
+        {
+            var testCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using static System.Threading.Thread;
+
+class ClassA
+{
+    public async Task<int> MethodAsync()
+    {
+        Sleep(1);
+        Thread.Sleep(2);
+        System.Threading.Thread.Sleep(3);
+        global::System.Threading.Thread.Sleep(4);
+        
+        return await Task.FromResult(0); 
+    }
+}";
+            var fixedCode = @"
+using System.Threading;
+using System.Threading.Tasks;
+using static System.Threading.Thread;
+
+class ClassA
+{
+    public async Task<int> MethodAsync()
+    {
+        await System.Threading.Tasks.Task.Delay(1);
+        await System.Threading.Tasks.Task.Delay(2);
+        await System.Threading.Tasks.Task.Delay(3);
+        await System.Threading.Tasks.Task.Delay(4);
+        
+        return await Task.FromResult(0); 
+    }
+}";
+            var expectedResults = new[]
+                {
+                    this.CSharpDiagnostic().WithLocation(10, 9),
+                    this.CSharpDiagnostic().WithLocation(11, 9),
+                    this.CSharpDiagnostic().WithLocation(12, 9),
+                    this.CSharpDiagnostic().WithLocation(13, 9)
+                }
+                .Select(diag => this.OptionallyAddArgumentsToDiagnostic(diag, string.Format(UsageResources.MethodFormat, "MethodAsync")))
+                .ToArray();
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(
+                    testCode,
+                    fixedCode,
+                    cancellationToken: CancellationToken.None,
+                    allowNewCompilerDiagnostics: true /* expected new diagnostic is "hidden CS8019: Unnecessary using directive." */)
+                .ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreadSleepInAsyncAnonymousFunctionAsync()
+        {
+            var testCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ClassA
+{
+    public void MethodA()
+    {
+        Func<Task> testFunc = async () =>
+        {
+            Thread.Sleep(1);
+            await Task.FromResult(1);
+        };
+    }
+}";
+
+            var fixedCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ClassA
+{
+    public void MethodA()
+    {
+        Func<Task> testFunc = async () =>
+        {
+            await System.Threading.Tasks.Task.Delay(1);
+            await Task.FromResult(1);
+        };
+    }
+}";
+            var expected = this.OptionallyAddArgumentsToDiagnostic(this.CSharpDiagnostic().WithLocation(12, 13), UsageResources.AsyncAnonymousFunctionsAndMethods);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(
+                    testCode,
+                    fixedCode,
+                    cancellationToken: CancellationToken.None,
+                    allowNewCompilerDiagnostics: true /* expected new diagnostic is "hidden CS8019: Unnecessary using directive." */)
+                .ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreadSleepInAsyncAnonymousMethodAsync()
+        {
+            var testCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ClassA
+{
+    public delegate Task<int> SampleDelegate();
+    SampleDelegate AsyncAnonymousMethod = async delegate ()
+    {
+        Thread.Sleep(0);
+        return await Task.FromResult(0);
+    };
+}";
+            var fixedCode = @"
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+class ClassA
+{
+    public delegate Task<int> SampleDelegate();
+    SampleDelegate AsyncAnonymousMethod = async delegate ()
+    {
+        await System.Threading.Tasks.Task.Delay(0);
+        return await Task.FromResult(0);
+    };
+}";
+            var result = this.OptionallyAddArgumentsToDiagnostic(this.CSharpDiagnostic().WithLocation(11, 9), UsageResources.AsyncAnonymousFunctionsAndMethods);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, result, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(
+                    testCode,
+                    fixedCode,
+                    cancellationToken: CancellationToken.None,
+                    allowNewCompilerDiagnostics: true /* expected new diagnostic is "hidden CS8019: Unnecessary using directive." */)
+                .ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestUsingTaskDelayIsOKAsync()
+        {
+            var testCode = @"
+using System.Threading.Tasks;
+using System.Threading;
+
+class ClassA
+{
+    public async Task<int> Method1Async()
+    {
+        await Task.Delay(1000);
+        return await Task.FromResult(0); 
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new DontUseThreadSleepCodeUniversalCodeFixProvider();
+        }
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/packages.config
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers.Test/packages.config
@@ -1,15 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net452" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0-rc3" targetFramework="net452" developmentDependency="true" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
+  <package id="System.Collections" version="4.0.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.0.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.0.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.0.0" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.0.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.0.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.0.0" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/AsyncUsageAnalyzers.csproj
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/AsyncUsageAnalyzers.csproj
@@ -124,16 +124,16 @@
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Composition.AttributedModel, Version=1.0.27.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -156,15 +156,15 @@
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.2.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.2.0\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha003\analyzers\dotnet\AsyncUsageAnalyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-rc3\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/AsyncUsageAnalyzers.csproj
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/AsyncUsageAnalyzers.csproj
@@ -55,6 +55,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>HelpersResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Helpers\InvocationExpressionSyntaxExtensions.cs" />
     <Compile Include="Helpers\MethodSymbolExtensions.cs" />
     <Compile Include="Helpers\SpecializedTasks.cs" />
     <Compile Include="Helpers\SymbolExtensions.cs" />
@@ -79,13 +80,16 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <Compile Include="Usage\DontUseThreadSleepAnalyzer.cs" />
+    <Compile Include="Usage\DontUseThreadSleepAnalyzerBase.cs" />
+    <Compile Include="Usage\DontUseThreadSleepInAsyncCodeAnalyzer.cs" />
     <Compile Include="Usage\IncludeCancellationParameterAnalyzer.cs" />
+    <Compile Include="Usage\UseConfigureAwaitAnalyzer.cs" />
     <Compile Include="Usage\UsageResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>UsageResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Usage\UseConfigureAwaitAnalyzer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Helpers\HelpersResources.resx">

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Helpers/InvocationExpressionSyntaxExtensions.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Helpers/InvocationExpressionSyntaxExtensions.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Helpers
+{
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    internal static class InvocationExpressionSyntaxExtensions
+    {
+        public static bool TryGetMethodSymbolByTypeNameAndMethodName(
+            this InvocationExpressionSyntax invocationExpression,
+            SemanticModel semanticModel,
+            string fullyQualifiedName,
+            string methodName,
+            out IMethodSymbol methodSymbol)
+        {
+            methodSymbol = ModelExtensions.GetSymbolInfo(semanticModel, invocationExpression).Symbol as IMethodSymbol;
+            if (methodSymbol == null)
+            {
+                return false;
+            }
+
+            var threadTypeMetadata = semanticModel.Compilation.GetTypeByMetadataName(fullyQualifiedName);
+            if (!threadTypeMetadata.Equals(methodSymbol.ReceiverType))
+            {
+                return false;
+            }
+
+            if (methodSymbol.Name != methodName)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public static bool IsInsideAsyncCode(this InvocationExpressionSyntax invocationExpression, ref SyntaxNode enclosingMethodOrFunctionDeclaration)
+        {
+            foreach (var syntaxNode in invocationExpression.Ancestors())
+            {
+                var methodDeclaration = syntaxNode as MethodDeclarationSyntax;
+                if (methodDeclaration != null)
+                {
+                    enclosingMethodOrFunctionDeclaration = syntaxNode;
+                    return HasAsyncMethodModifier(methodDeclaration);
+                }
+
+                // This handles also AnonymousMethodExpressionSyntax since AnonymousMethodExpressionSyntax inherits from AnonymousFunctionExpressionSyntax
+                var anonymousFunction = syntaxNode as AnonymousFunctionExpressionSyntax;
+                if (anonymousFunction != null)
+                {
+                    enclosingMethodOrFunctionDeclaration = syntaxNode;
+                    return IsAsyncAnonymousFunction(anonymousFunction);
+                }
+            }
+
+            return false;
+        }
+
+        public static bool IsInsideAsyncCode(this InvocationExpressionSyntax invocationExpression)
+        {
+            SyntaxNode enclosingMethodOrFunctionDeclaration = null;
+            return invocationExpression.IsInsideAsyncCode(ref enclosingMethodOrFunctionDeclaration);
+        }
+
+        private static bool HasAsyncMethodModifier(MethodDeclarationSyntax methodDeclaration) =>
+            methodDeclaration.Modifiers.Any(x => x.Kind() == SyntaxKind.AsyncKeyword);
+
+        private static bool IsAsyncAnonymousFunction(AnonymousFunctionExpressionSyntax anonymousFunctionExpressionSyntax) =>
+            anonymousFunctionExpressionSyntax.AsyncKeyword.Kind() == SyntaxKind.AsyncKeyword;
+
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/DontUseThreadSleepAnalyzer.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/DontUseThreadSleepAnalyzer.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Usage
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// This analyzer reports a diagnostic if System.Threading.Thread.Sleep() method is called.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class DontUseThreadSleepAnalyzer : DontUseThreadSleepAnalyzerBase
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="DontUseThreadSleepAnalyzer"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "DontUseThreadSleep";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(UsageResources.DontUseThreadSleepTitle), UsageResources.ResourceManager, typeof(UsageResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(UsageResources.DontUseThreadSleepMessageFormat), UsageResources.ResourceManager, typeof(UsageResources));
+        private static readonly string Category = "AsyncUsage.CSharp.Usage";
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(UsageResources.DontUseThreadSleepDescription), UsageResources.ResourceManager, typeof(UsageResources));
+        private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/AsyncUsageAnalyzers/blob/master/documentation/DontUseThreadSleep.md";
+        private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(Descriptor);
+
+        protected override AnalyzerBase GetAnalyzer() => new Analyzer();
+
+        private sealed class Analyzer : DontUseThreadSleepAnalyzerBase.AnalyzerBase
+        {
+            protected override void ReportDiagnosticOnThreadSleepInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpression)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationExpression.GetLocation()));
+            }
+        }
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/DontUseThreadSleepAnalyzerBase.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/DontUseThreadSleepAnalyzerBase.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Usage
+{
+    using AsyncUsageAnalyzers.Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// This analyzer is a base class for analyzers repoting usage of System.Threading.Thread.Sleep() method in various scenerios.
+    /// </summary>
+    public abstract class DontUseThreadSleepAnalyzerBase : DiagnosticAnalyzer
+    {
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            var analyzer = this.GetAnalyzer();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(analyzer.HandleInvocation, SyntaxKind.InvocationExpression);
+        }
+
+        protected abstract AnalyzerBase GetAnalyzer();
+
+        protected abstract class AnalyzerBase
+        {
+            protected abstract void ReportDiagnosticOnThreadSleepInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpression);
+
+            internal void HandleInvocation(SyntaxNodeAnalysisContext context)
+            {
+                var invocationExpression = (InvocationExpressionSyntax)context.Node;
+
+                var semanticModel = context.SemanticModel;
+                var fullyQualifiedName = "System.Threading.Thread";
+                var methodName = "Sleep";
+
+                // This check aims at increasing the performance.
+                // Thanks to it, getting a semantic model in not necessary in majority of cases.
+                if (!invocationExpression.Expression.GetText().ToString().Contains(methodName))
+                {
+                    return;
+                }
+
+                IMethodSymbol methodSymbol;
+                if (!invocationExpression.TryGetMethodSymbolByTypeNameAndMethodName(semanticModel, fullyQualifiedName, methodName, out methodSymbol))
+                {
+                    return;
+                }
+
+                this.ReportDiagnosticOnThreadSleepInvocation(context, invocationExpression);
+            }
+         }
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/DontUseThreadSleepInAsyncCodeAnalyzer.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/DontUseThreadSleepInAsyncCodeAnalyzer.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+/* Contributor: Tomasz Maczyński */
+
+namespace AsyncUsageAnalyzers.Usage
+{
+    using System.Collections.Immutable;
+    using AsyncUsageAnalyzers.Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// This analyzer reports a diagnostic if System.Threading.Thread.Sleep() method is inside async code
+    /// (i.e. asynchronous methods, asynchronous anonymous functions or asynchronous anonymous methods).
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class DontUseThreadSleepInAsyncCodeAnalyzer : DontUseThreadSleepAnalyzerBase
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="DontUseThreadSleepInAsyncCodeAnalyzer"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "DontUseThreadSleepInAsyncCode";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(UsageResources.DontUseThreadSleepInAsyncCodeTitle), UsageResources.ResourceManager, typeof(UsageResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(UsageResources.DontUseThreadSleepInAsyncCodeMessageFormat), UsageResources.ResourceManager, typeof(UsageResources));
+        private static readonly string Category = "AsyncUsage.CSharp.Usage";
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(UsageResources.DontUseThreadSleepInAsyncCodeDescription), UsageResources.ResourceManager, typeof(UsageResources));
+        private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/AsyncUsageAnalyzers/blob/master/documentation/DontUseThreadSleepInAsyncCode.md";
+        private static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(Descriptor);
+
+        protected override AnalyzerBase GetAnalyzer() => new Analyzer();
+
+        private sealed class Analyzer : DontUseThreadSleepAnalyzerBase.AnalyzerBase
+        {
+            protected override void ReportDiagnosticOnThreadSleepInvocation(SyntaxNodeAnalysisContext context, InvocationExpressionSyntax invocationExpression)
+            {
+                SyntaxNode asycNode = null;
+                if (invocationExpression.IsInsideAsyncCode(ref asycNode))
+                {
+                    var asyncMethod = asycNode as MethodDeclarationSyntax;
+                    if (asyncMethod != null)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationExpression.GetLocation(), GetMethodText(asyncMethod.Identifier.Text)));
+                    }
+
+                    var asyncFunction = asycNode as AnonymousFunctionExpressionSyntax;
+                    if (asyncFunction != null)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, invocationExpression.GetLocation(), UsageResources.AsyncAnonymousFunctionsAndMethods));
+                    }
+                }
+            }
+        }
+
+        private static string GetMethodText(string methodName) =>
+            string.Format(UsageResources.MethodFormat, methodName);
+    }
+}

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/UsageResources.Designer.cs
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/UsageResources.Designer.cs
@@ -62,6 +62,69 @@ namespace AsyncUsageAnalyzers.Usage {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Asynchronous anonymous functions and methods.
+        /// </summary>
+        internal static string AsyncAnonymousFunctionsAndMethods {
+            get {
+                return ResourceManager.GetString("AsyncAnonymousFunctionsAndMethods", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t use Thread.Sleep() .
+        /// </summary>
+        internal static string DontUseThreadSleepDescription {
+            get {
+                return ResourceManager.GetString("DontUseThreadSleepDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t use Thread.Sleep() in a aync code.
+        /// </summary>
+        internal static string DontUseThreadSleepInAsyncCodeDescription {
+            get {
+                return ResourceManager.GetString("DontUseThreadSleepInAsyncCodeDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} should not call Thread.Sleep().
+        /// </summary>
+        internal static string DontUseThreadSleepInAsyncCodeMessageFormat {
+            get {
+                return ResourceManager.GetString("DontUseThreadSleepInAsyncCodeMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t use Thread.Sleep() In async code.
+        /// </summary>
+        internal static string DontUseThreadSleepInAsyncCodeTitle {
+            get {
+                return ResourceManager.GetString("DontUseThreadSleepInAsyncCodeTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Thread.Sleep() should not be used.
+        /// </summary>
+        internal static string DontUseThreadSleepMessageFormat {
+            get {
+                return ResourceManager.GetString("DontUseThreadSleepMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Don&apos;t use Thread.Sleep().
+        /// </summary>
+        internal static string DontUseThreadSleepTitle {
+            get {
+                return ResourceManager.GetString("DontUseThreadSleepTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Asynchronous methods should include a CancellationToken parameter..
         /// </summary>
         internal static string IncludeCancellationParameterDescription {
@@ -85,6 +148,24 @@ namespace AsyncUsageAnalyzers.Usage {
         internal static string IncludeCancellationParameterTitle {
             get {
                 return ResourceManager.GetString("IncludeCancellationParameterTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to lambda function.
+        /// </summary>
+        internal static string LambdaFunction {
+            get {
+                return ResourceManager.GetString("LambdaFunction", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Method &apos;{0}&apos;.
+        /// </summary>
+        internal static string MethodFormat {
+            get {
+                return ResourceManager.GetString("MethodFormat", resourceCulture);
             }
         }
         

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/UsageResources.resx
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/Usage/UsageResources.resx
@@ -117,6 +117,27 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AsyncAnonymousFunctionsAndMethods" xml:space="preserve">
+    <value>Asynchronous anonymous functions and methods</value>
+  </data>
+  <data name="DontUseThreadSleepDescription" xml:space="preserve">
+    <value>Don't use Thread.Sleep() </value>
+  </data>
+  <data name="DontUseThreadSleepInAsyncCodeDescription" xml:space="preserve">
+    <value>Don't use Thread.Sleep() in a aync code</value>
+  </data>
+  <data name="DontUseThreadSleepInAsyncCodeMessageFormat" xml:space="preserve">
+    <value>{0} should not call Thread.Sleep()</value>
+  </data>
+  <data name="DontUseThreadSleepInAsyncCodeTitle" xml:space="preserve">
+    <value>Don't use Thread.Sleep() In async code</value>
+  </data>
+  <data name="DontUseThreadSleepMessageFormat" xml:space="preserve">
+    <value>Thread.Sleep() should not be used</value>
+  </data>
+  <data name="DontUseThreadSleepTitle" xml:space="preserve">
+    <value>Don't use Thread.Sleep()</value>
+  </data>
   <data name="IncludeCancellationParameterDescription" xml:space="preserve">
     <value>Asynchronous methods should include a CancellationToken parameter.</value>
   </data>
@@ -125,6 +146,12 @@
   </data>
   <data name="IncludeCancellationParameterTitle" xml:space="preserve">
     <value>Include CancellationToken parameter</value>
+  </data>
+  <data name="LambdaFunction" xml:space="preserve">
+    <value>lambda function</value>
+  </data>
+  <data name="MethodFormat" xml:space="preserve">
+    <value>Method '{0}'</value>
   </data>
   <data name="UseConfigureAwaitDescription" xml:space="preserve">
     <value>The continuation behavior for a Task should be configured by calling ConfigureAwait prior to awaiting the task.</value>

--- a/AsyncUsageAnalyzers/AsyncUsageAnalyzers/packages.config
+++ b/AsyncUsageAnalyzers/AsyncUsageAnalyzers/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="portable45-net45+win8" developmentDependency="true" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="portable45-net45+win8" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="portable45-net45+win8" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="portable45-net45+win8" />
   <package id="StyleCop.Analyzers" version="1.0.0-rc3" targetFramework="portable45-net45+win8" developmentDependency="true" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="portable45-net45+win8" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="portable45-net45+win8" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
+  <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="portable45-net45+win8" />
 </packages>

--- a/DontUseThreadSleep.md
+++ b/DontUseThreadSleep.md
@@ -1,0 +1,46 @@
+## DontUseThreadSleep
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>DontUseThreadSleep</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>DontUseThreadSleep</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Usage Rules</td>
+</tr>
+</table>
+
+## Cause
+
+System.Threading.Thread.Sleep() method is called in the code.
+
+## Rule description
+
+System.Threading.Thread.Sleep() method is called in the code. 
+If this method is in code which can executed asynchronously, the code is not optimal - the thread that is sleeping cannot execute any other tasks.
+Note that non-async method might be called from asynchronous code and in such circumstances the thread cannot execute other task.
+In such case, consider refactoring your code.
+There are cases when using Thread.Sleep() method is valid.
+
+## How to fix violations
+
+If identified method call is inside asynchronous method or function, consider using "await System.Threading.Tasks.Task.Delay(...)" as an alternative.
+If you are sure that using Thread.Sleep() is approprate, suppress violations as described below.
+You may use less strict rule (e.g. DontUseThreadSleepInAsyncCode) or opt-out of this rule completely.
+
+## How to suppress violations
+
+```csharp
+[SuppressMessage("AsyncUsage.CSharp.Usage", "DontUseThreadSleep", Justification = "Reviewed.")]
+```
+
+```csharp
+#pragma warning disable DontUseThreadSleep // Use Async suffix
+Thread.Sleep(1000)
+#pragma warning restore DontUseThreadSleep // Use Async suffix
+```

--- a/DontUseThreadSleepInAsyncCode.md
+++ b/DontUseThreadSleepInAsyncCode.md
@@ -1,0 +1,42 @@
+## DontUseThreadSleepInAsyncCode
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>DontUseThreadSleepInAsyncCode</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>DontUseThreadSleepInAsyncCode</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Usage Rules</td>
+</tr>
+</table>
+
+## Cause
+
+System.Threading.Thread.Sleep() method is called in the async code (i.e. asynchronous method, asynchronous anonymous function or asynchronous anonymous method).
+
+## Rule description
+
+System.Threading.Thread.Sleep() method is called in the asynchronous code. 
+The code is not optimal - the thread that is sleeping cannot execute any other tasks.
+
+## How to fix violations
+
+Use "await System.Threading.Tasks.Task.Delay(...)" instead. 
+If a sleep is interrupted by some other thread, use overload of Task.Delay() which takes a cancallation token.
+
+## How to suppress violations
+
+```csharp
+[SuppressMessage("AsyncUsage.CSharp.Usage", "DontUseThreadSleep", Justification = "Reviewed.")]
+```
+
+```csharp
+#pragma warning disable DontUseThreadSleep // Use Async suffix
+Thread.Sleep(1000)
+#pragma warning restore DontUseThreadSleep // Use Async suffix
+```


### PR DESCRIPTION
I've created two analyzers:
- first which reports usage of Thread.Sleep() inside of asynchronous code (i.e. asynchronous methods, asynchronous anonymous functions or asynchronous anonymous methods).
- second which reports usage of Thread.Sleep() anywhere
Analyzers have a  common code fix which fixes occurrences of Thread.Sleep() in async code. If Thread.Sleep is used in non async code, there's no obvious automatic fix for the code, so no codefix is proposed.

I think that the first analysis should be active by default.

I've updated version of Microsoft.CodeAnalysis in a separate commit - if I recall correctly, I needed some functionality from the newer version. I did not observe any regression.

I've also updated a version of Visual Studio in sln file in a separate commit. I guess that majority of people use the most recent version of VS2015 so I think that it's convenient to include that change in repo.

